### PR TITLE
Further tweaks to new public types

### DIFF
--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -39,7 +39,8 @@ pub struct JobDescriptor {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SubmitPackageRequest {
     /// The 'type' of package, NPM, RubyGem, etc
-    pub r#type: PackageType,
+    #[serde(rename = "type")]
+    pub package_type: PackageType,
     /// The subpackage dependencies of this package
     pub packages: Vec<PackageDescriptor>,
     /// Was this submitted by a user interactively and not a CI?
@@ -52,7 +53,7 @@ pub struct SubmitPackageRequest {
 
 /// Initial response after package has been submitted
 #[derive(Debug, Serialize, Deserialize)]
-pub struct PackageSubmissionResponse {
+pub struct SubmitPackageResponse {
     /// The id of the job processing the package
     pub job_id: JobId,
 }

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -46,6 +46,12 @@ pub struct ProjectDetailsResponse {
     pub jobs: Vec<JobDescriptor>,
 }
 
+/// Rquest to create a project
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateProjectRequest {
+    pub name: String,
+}
+
 /// Response of a create project request
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateProjectResponse {


### PR DESCRIPTION
* Add a create project response object
* Use serde rename to keep field name the same in json, but change
  rust field names to package_type
* TODO We should avoid the use of 'type' in json formats as some
  libraries informally reserve this key for encoding type information
  in output