### PR TITLE
Daniel/fix project types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "phylum_types"
 description = "Common public types shared between the Phylum CLI and API"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
+[features]
+dev_api_issue_96 = ["chrono"]
+
 [dependencies]
+chrono = { version = "0.4.11", default-features = true, features = [
+    "serde",
+], optional = true }
 log = "^0.4.6"
 serde = { version = "^1.0", features = ["derive"] }
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phylum_types"
 description = "Common public types shared between the Phylum CLI and API"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2018"
 
 [features]

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -1,5 +1,6 @@
 //! This module contains types for working with project data
-
+#[cfg(feature = "dev_api_issue_96")]
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::common::ProjectId;
@@ -17,6 +18,7 @@ pub struct ProjectThresholds {
 }
 
 /// Summary response for a project
+#[cfg(not(feature = "dev_api_issue_96"))]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProjectSummaryResponse {
     /// The project name
@@ -24,8 +26,23 @@ pub struct ProjectSummaryResponse {
     /// The project id
     pub id: String,
     /// When the project was updated
-    // TODO Fix, make consistent with other timestamps in the api
     pub updated_at: String,
+    /* TODO: Need to update request manager to include thresholds with this
+     *       response.
+     *pub thresholds: ProjectThresholds, */
+}
+
+/// Summary response for a project
+#[cfg(feature = "dev_api_issue_96")]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectSummaryResponse {
+    /// The project name
+    pub name: String,
+    /// The project id
+    pub id: ProjectId,
+    /// When the project was updated
+    pub updated_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
     /* TODO: Need to update request manager to include thresholds with this
      *       response.
      *pub thresholds: ProjectThresholds, */


### PR DESCRIPTION
Needed to clean up and extend types, so putting the changes behind the same feature flag name as API

Once the request manager supports lands in API and CLI is updated, we can pull this feature flag and bump version numbers.