### PR TITLE
Add derives for common traits

### DIFF
--- a/src/ecosystems/maven.rs
+++ b/src/ecosystems/maven.rs
@@ -1,7 +1,8 @@
 // This is a reference for the Maven project descriptor used in Maven.
 // https://maven.apache.org/ref/3.8.4/maven-model/maven.html
 
-use std::{collections::HashMap, ops::Deref};
+use std::collections::HashMap;
+use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/types/auth.rs
+++ b/src/types/auth.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 /// Typed wrapper for AuthorizationCode as used in OAuth login flow with PKCE
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthorizationCode(String);
 
 impl AuthorizationCode {
@@ -21,7 +21,7 @@ impl From<&AuthorizationCode> for String {
 }
 
 /// Typed wrapper for RefreshToken
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Serialize, Deserialize)]
 pub struct RefreshToken(String);
 
 impl RefreshToken {
@@ -43,7 +43,7 @@ impl fmt::Display for RefreshToken {
 }
 
 /// Typed wrapper for AccessToken
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Serialize, Deserialize)]
 pub struct AccessToken(String);
 
 impl AccessToken {
@@ -65,7 +65,7 @@ impl<'a> From<&'a AccessToken> for &'a str {
 }
 
 /// Typed wrapper for IdToken
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Serialize, Deserialize)]
 pub struct IdToken(String);
 
 impl IdToken {
@@ -83,7 +83,7 @@ impl From<&IdToken> for String {
 /// Represents a response from a OAuth server containing
 /// refresh and access tokens obtained from the final stage
 /// of the OAuth login flow with PKCE
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Serialize, Deserialize)]
 pub struct TokenResponse {
     pub access_token: AccessToken,
     pub refresh_token: RefreshToken,
@@ -95,7 +95,7 @@ pub struct TokenResponse {
 /// Reprsents a refresh token response from a OAuth server after
 /// a request was made to obtain a new Access Token using the current
 /// Refresh Token
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Serialize, Deserialize)]
 pub struct AccessTokenResponse {
     pub access_token: AccessToken,
     #[serde(rename = "expires_in")]

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -8,7 +8,7 @@ pub type Key = Uuid;
 pub type PackageId = String;
 
 /// Did the processing of the Package or Job complete successfully
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Status {
     Complete,

--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -10,7 +10,7 @@ use super::project::*;
 /// level ), what action should be taken?
 /// In the case of the CLI, the value of this result is used to determine if the
 /// CLI should print a warning, or exit with a non-zero exit code.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Action {
     None,
@@ -19,7 +19,7 @@ pub enum Action {
 }
 
 /// Metadata about a job
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct JobDescriptor {
     pub job_id: JobId,
     pub project: String,
@@ -36,7 +36,7 @@ pub struct JobDescriptor {
 }
 
 /// Submit Package for analysis
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct SubmitPackageRequest {
     /// The 'type' of package, NPM, RubyGem, etc
     #[serde(rename = "type")]
@@ -52,14 +52,14 @@ pub struct SubmitPackageRequest {
 }
 
 /// Initial response after package has been submitted
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct SubmitPackageResponse {
     /// The id of the job processing the package
     pub job_id: JobId,
 }
 
 /// Represents a response that summarizes the output of all current jobs
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct AllJobsStatusResponse {
     /// A description of the latest jobs
     pub jobs: Vec<JobDescriptor>,
@@ -68,7 +68,7 @@ pub struct AllJobsStatusResponse {
     pub count: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum JobStatusResponseVariant {
     // Serde returns the one that deserializes successfully first, so most complicated goes first
@@ -77,7 +77,7 @@ pub enum JobStatusResponseVariant {
 }
 
 /// Data returned when querying the job status endpoint
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct JobStatusResponse<T> {
     /// The id of the job processing the top level package
     pub job_id: JobId,
@@ -118,7 +118,7 @@ pub struct JobStatusResponse<T> {
 }
 
 /// Response from canceling a job
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct CancelJobResponse {
     pub msg: String,
 }

--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -10,7 +10,7 @@ use super::common::*;
 
 /// The package ecosystem
 // TODO Should be Ecosystem?
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PackageType {
     Npm,
@@ -21,7 +21,7 @@ pub enum PackageType {
 }
 
 /// Human friendly risk level buckets
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum RiskLevel {
     /// Informational, no action needs to be taken
     #[serde(rename = "info")]
@@ -48,7 +48,7 @@ impl fmt::Display for RiskLevel {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug, Serialize, Deserialize)]
 // TODO Naming here seems inconsisten, some have Risk as a suffix, others don't
 pub enum RiskDomain {
     /// Malicious code such as malware or crypto miners
@@ -83,7 +83,7 @@ impl fmt::Display for RiskDomain {
 }
 
 /// Represents an actionable issue found in a package
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Serialize, Deserialize)]
 pub struct Issue {
     /// Name of issue
     pub title: String,
@@ -98,7 +98,7 @@ pub struct Issue {
 }
 
 /// The results of an individual heuristic run
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct HeuristicResult {
     /// The risk domain
     pub domain: RiskDomain,
@@ -109,7 +109,7 @@ pub struct HeuristicResult {
 }
 
 /// A vulnerability
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct Vulnerability {
     /// If this vulnerability falls into one or more known CVEs
     pub cve: Vec<String>,
@@ -161,7 +161,7 @@ impl PackageType {
 }
 
 /// Describes a package in the system
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct PackageDescriptor {
     pub name: String,
     pub version: String,
@@ -171,7 +171,7 @@ pub struct PackageDescriptor {
 
 /// Basic core package meta data
 // TODO Clearer name
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct PackageStatus {
     /// Name of the package
     pub name: String,
@@ -196,7 +196,7 @@ pub struct PackageStatus {
 
 /// Package metadata with extended info info
 // TODO Clearer name
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct PackageStatusExtended {
     #[serde(flatten)]
     pub basic_status: PackageStatus,

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -7,7 +7,7 @@ use super::common::ProjectId;
 use super::job::*;
 
 /// Rick cut off thresholds for a project
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, PartialOrd, Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct ProjectThresholds {
     pub author: f32,
     pub engineering: f32,
@@ -19,7 +19,7 @@ pub struct ProjectThresholds {
 
 /// Summary response for a project
 #[cfg(not(feature = "dev_api_issue_96"))]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct ProjectSummaryResponse {
     /// The project name
     pub name: String,
@@ -34,7 +34,7 @@ pub struct ProjectSummaryResponse {
 
 /// Summary response for a project
 #[cfg(feature = "dev_api_issue_96")]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct ProjectSummaryResponse {
     /// The project name
     pub name: String,
@@ -49,7 +49,7 @@ pub struct ProjectSummaryResponse {
 }
 
 /// A more detailed project response
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct ProjectDetailsResponse {
     /// The project name
     pub name: String,
@@ -64,7 +64,7 @@ pub struct ProjectDetailsResponse {
 }
 
 /// Rquest to create a project
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct CreateProjectRequest {
     pub name: String,
 }
@@ -72,7 +72,7 @@ pub struct CreateProjectRequest {
 pub type UpdateProjectRequest = CreateProjectRequest;
 
 /// Response of a create project request
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct CreateProjectResponse {
     /// The id of the newly created project
     pub id: ProjectId,

--- a/src/types/user_settings.rs
+++ b/src/types/user_settings.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 /// Threshold for a given risk
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct Threshold {
     // TODO Should this be the Action enum?
     pub action: String,
@@ -15,12 +15,12 @@ pub struct Threshold {
     pub threshold: f32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct UserProject {
     pub thresholds: HashMap<String, Threshold>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Setting {
     DefaultLabel(HashMap<String, String>),
@@ -29,7 +29,7 @@ pub enum Setting {
 
 /// Exposes the user settings most often used by the CLI
 // TODO Unify with API user settings type
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct UserSettings {
     pub version: u32,
     pub projects: HashMap<String, Setting>,


### PR DESCRIPTION
To ensure that the `phylum-types` crate doesn't have to be constantly
changed to allow for dependents to use specific traits for the types
inside this crate, all common traits have been implemented for all
existing types.

The chosen traits are based on
https://rust-lang.github.io/api-guidelines/interoperability.html and
have been derived wherever possible without worrying too much about
their intended usecase. This should especially be helpful for test code
which is usually a bit more practical than efficient.