### PR TITLE
Group Accounts API structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,8 @@ description = "Common public types shared between the Phylum CLI and API"
 version = "0.1.0"
 edition = "2018"
 
-[features]
-dev_api_issue_96 = ["chrono"]
-
 [dependencies]
-chrono = { version = "0.4.11", default-features = true, features = [
-    "serde",
-], optional = true }
+chrono = { version = "0.4.11", default-features = true, features = ["serde"] }
 log = "^0.4.6"
 serde = { version = "^1.0", features = ["derive"] }
 serde_derive = "1.0"

--- a/src/types/group.rs
+++ b/src/types/group.rs
@@ -1,0 +1,51 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct CreateGroupRequest {
+    pub group_name: String,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct CreateGroupResponse {
+    pub group_name: String,
+    pub owner_email: String,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct AddUserToGroupRequest {
+    pub user_email: String,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct KickUserFromGroupRequest {
+    pub user_email: String,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+
+pub struct UserGroup {
+    pub created_at: DateTime<Utc>,
+    pub last_modified: DateTime<Utc>,
+    pub owner_email: String,
+    pub group_name: String,
+    pub is_admin: Option<bool>, //only present in the relatively uncommon case that the user is an admin
+    pub is_owner: Option<bool>, //only present in the relatively uncommon case that the user is the owner
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct ListUserGroupsResponse {
+    pub groups: Vec<UserGroup>,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct GroupMember {
+    pub user_email: String,
+    pub first_name: String,
+    pub last_name: String,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
+pub struct ListGroupMembersResponse {
+    pub members: Vec<GroupMember>
+}

--- a/src/types/group.rs
+++ b/src/types/group.rs
@@ -23,7 +23,6 @@ pub struct KickUserFromGroupRequest {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
-
 pub struct UserGroup {
     pub created_at: DateTime<Utc>,
     pub last_modified: DateTime<Utc>,

--- a/src/types/group.rs
+++ b/src/types/group.rs
@@ -28,8 +28,14 @@ pub struct UserGroup {
     pub last_modified: DateTime<Utc>,
     pub owner_email: String,
     pub group_name: String,
-    pub is_admin: Option<bool>, //only present in the relatively uncommon case that the user is an admin
-    pub is_owner: Option<bool>, //only present in the relatively uncommon case that the user is the owner
+
+    //only present in the relatively uncommon case that the user is an admin
+    #[serde(default)]
+    pub is_admin: bool,
+
+    //only present in the relatively uncommon case that the user is the owner
+    #[serde(default)]
+    pub is_owner: bool,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -8,3 +8,4 @@ pub mod job;
 pub mod package;
 pub mod project;
 pub mod user_settings;
+pub mod group;

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -67,6 +67,7 @@ pub struct ProjectDetailsResponse {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct CreateProjectRequest {
     pub name: String,
+    pub group_name: Option<String>
 }
 
 pub type UpdateProjectRequest = CreateProjectRequest;


### PR DESCRIPTION
Added Group Accounts API response structs, made chrono dependency no longer optional, and also added the optional group_name for create project request