### PR TITLE
Allow freely setting project thresholds

### DIFF
--- a/src/types/user_settings.rs
+++ b/src/types/user_settings.rs
@@ -37,13 +37,7 @@ pub struct UserSettings {
 
 impl UserSettings {
     /// Sets the threshold for the given risk domain.
-    pub fn set_threshold(
-        &mut self,
-        project_id: String,
-        name: String,
-        threshold: i32,
-        action: String,
-    ) {
+    pub fn set_threshold(&mut self, project_id: String, name: String, threshold: Threshold) {
         // log::debug!("Retrieving user settings for project: {}", project_id);
         let mut thresholds = self
             .projects
@@ -56,14 +50,7 @@ impl UserSettings {
             });
 
         if let Setting::Project(ref mut t) = thresholds {
-            t.thresholds.insert(
-                name,
-                Threshold {
-                    action,
-                    active: (threshold > 0),
-                    threshold: (threshold as f32) / 100.0,
-                },
-            );
+            t.thresholds.insert(name, threshold);
         }
 
         self.projects.insert(project_id, thresholds);


### PR DESCRIPTION
Previously the `active` field of the thresholds struct was populated by
checking whether the `threshold` was above `0` or not. However the
`Total Project Threshold` can never be disabled and it is possible for
other thresholds to be at `0` without being disabled too.

To ensure a more accurate representation of the backend state, the
`set_threshold` method instead takes a `Threshold` instance which can be
populated fully by the consumer without any internal restrictions.

See phylum-dev/cli#288.