### PR TITLE
Bump uuid from 0.8.0 -> 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4.11", default-features = false, features = ["serde"] }
 log = "^0.4.6"
-schemars = { version = "0.8", features = ["chrono", "uuid08"] }
+schemars = { version = "0.8", features = ["chrono", "uuid1"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_derive = "1.0"
-uuid = { version = "1.0.0", features = ["serde", "v4"] }
+uuid = { version = "1.1.2", features = ["serde", "v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ chrono = { version = "0.4.11", default-features = true, features = ["serde"] }
 log = "^0.4.6"
 serde = { version = "^1.0", features = ["derive"] }
 serde_derive = "1.0"
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "1.0.0", features = ["serde", "v4"] }


### PR DESCRIPTION
This patch bumps the version of the uuid crate to 1.0.0. This is a
breaking change because uuid is used in the public interface of this
crate.

Ref: phylum-dev/cli#326