### PR TITLE
Skip serialization of `group_name` when `None`

### DIFF
--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -67,6 +67,7 @@ pub struct ProjectDetailsResponse {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct CreateProjectRequest {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub group_name: Option<String>,
 }
 


### PR DESCRIPTION
See phylum-dev/cli#331.