### PR TITLE
Removed AddUserToGroupRequest since we url encode the target instead

### DIFF
--- a/src/types/group.rs
+++ b/src/types/group.rs
@@ -13,11 +13,6 @@ pub struct CreateGroupResponse {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
-pub struct AddUserToGroupRequest {
-    pub user_email: String,
-}
-
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct KickUserFromGroupRequest {
     pub user_email: String,
 }


### PR DESCRIPTION
We instead ended up using url encoding of the target of AdduserToGroupRequest so the message DTO struct is defunct