### PR TITLE
Accept risk_level and risk_domain when deserializing Issues

### DIFF
--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -168,7 +168,9 @@ pub struct Issue {
     pub id: Option<String>,
     pub title: String,
     pub description: String,
+    #[serde(alias = "risk_level")]
     pub severity: RiskLevel,
+    #[serde(alias = "risk_domain")]
     pub domain: RiskDomain,
 }
 


### PR DESCRIPTION
API still serializes these values as `risk_level` and `risk_domain`. This patch will update CLI to accept those names as well as `severity` and `domain`