### PR TITLE
Add ecosystem field to ProjectSummaryResponse

### DIFF
--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::common::ProjectId;
 use super::job::*;
+use super::package::PackageType;
 
 /// Rick cut off thresholds for a project
 #[derive(PartialEq, PartialOrd, Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -33,6 +34,7 @@ pub struct ProjectSummaryResponse {
     /* TODO: Need to update request manager to include thresholds with this
      *       response.
      *pub thresholds: ProjectThresholds, */
+    pub ecosystem: Option<PackageType>,
 }
 
 /// Summary response for a project
@@ -51,6 +53,7 @@ pub struct ProjectSummaryResponse {
     /* TODO: Need to update request manager to include thresholds with this
      *       response.
      *pub thresholds: ProjectThresholds, */
+    pub ecosystem: Option<PackageType>,
 }
 
 /// A more detailed project response


### PR DESCRIPTION
In order to return a value for `ecosystem` from the projects list endpoint (as requested by https://github.com/phylum-dev/api/issues/292), we need to add that field here to the `ProjectSummaryResponse` struct. I also added a derivation for the `sqlx::Type` trait in this PR, which is required in order to return a value of this type in a `RETURNING` sql clause.

I will link the dependant API PR here once it is posted.