### PR TITLE
Add group to project summaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,6 @@ description = "Common public types shared between the Phylum CLI and API"
 version = "0.1.0"
 edition = "2018"
 
-[features]
-dev_api_issue_96 = []
-
 [dependencies]
 chrono = { version = "0.4.11", default-features = true, features = ["serde"] }
 log = "^0.4.6"

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -31,10 +31,10 @@ pub struct ProjectSummaryResponse {
     pub id: String,
     /// When the project was updated
     pub updated_at: String,
-    /* TODO: Need to update request manager to include thresholds with this
-     *       response.
-     *pub thresholds: ProjectThresholds, */
+    /// The ecosystem of the project; determined by its latest job
     pub ecosystem: Option<PackageType>,
+    /// The project's group's name, if this is a group project
+    pub group_name: Option<String>,
 }
 
 /// Summary response for a project
@@ -49,11 +49,12 @@ pub struct ProjectSummaryResponse {
     pub id: ProjectId,
     /// When the project was updated
     pub updated_at: DateTime<Utc>,
+    /// When the project was created
     pub created_at: DateTime<Utc>,
-    /* TODO: Need to update request manager to include thresholds with this
-     *       response.
-     *pub thresholds: ProjectThresholds, */
+    /// The ecosystem of the project; determined by its latest job
     pub ecosystem: Option<PackageType>,
+    /// The project's group's name, if this is a group project
+    pub group_name: Option<String>,
 }
 
 /// A more detailed project response

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -1,5 +1,4 @@
 //! This module contains types for working with project data
-#[cfg(feature = "dev_api_issue_96")]
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -20,25 +19,6 @@ pub struct ProjectThresholds {
 }
 
 /// Summary response for a project
-#[cfg(not(feature = "dev_api_issue_96"))]
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize, JsonSchema,
-)]
-pub struct ProjectSummaryResponse {
-    /// The project name
-    pub name: String,
-    /// The project id
-    pub id: String,
-    /// When the project was updated
-    pub updated_at: String,
-    /// The ecosystem of the project; determined by its latest job
-    pub ecosystem: Option<PackageType>,
-    /// The project's group's name, if this is a group project
-    pub group_name: Option<String>,
-}
-
-/// Summary response for a project
-#[cfg(feature = "dev_api_issue_96")]
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize, JsonSchema,
 )]


### PR DESCRIPTION
### overview
- Adds group name to project summary response.
- Removes the `dev_api_issue_96` feature, as it does not appear to be necessary.

### context
Currently the `api` uses `dev_api_issue_96` but `cli` does not. However, the only difference is an additional `created_at` field when using the feature flag. This type will still be compatible with `cli`'s usage, which is solely:
- Used as a deserialization target from incoming json. Nothing changes here. (The incoming JSON already has these new fields, since they come from `api` which does use the feature flag; serde ignores these extra fields by default.)
- Used in rendering to the user.

This would only be a problem for CLI if they were constructing their own `ProjectSummaryResponse` types, without `created_at`, but they are not.

