### PR TITLE
Avoid default features for chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-chrono = { version = "0.4.11", default-features = true, features = ["serde"] }
+chrono = { version = "0.4.11", features = ["serde"] }
 log = "^0.4.6"
 schemars = { version = "0.8", features = ["chrono", "uuid08"] }
 serde = { version = "^1.0", features = ["derive"] }


### PR DESCRIPTION
The default set of features for `chrono` includes the `oldtime` feature, which pulls in a version of the `time` crate that has known security issues (documented [here](https://rustsec.org/advisories/RUSTSEC-2020-0071.html)).

The `phylum_types` crate doesn't actually use that feature and so should not enable it.