### PR TITLE
Be permissive when deserializing types

### DIFF
--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -293,6 +293,7 @@ pub struct DeveloperResponsiveness {
     JsonSchema,
 )]
 #[serde(rename_all = "camelCase")]
+#[serde(default)]
 pub struct IssueImpacts {
     pub low: u32,
     pub medium: u32,
@@ -315,8 +316,9 @@ impl From<&[Issue]> for IssueImpacts {
     }
 }
 
-#[derive(PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[serde(default)]
 pub struct Package {
     pub id: String,
     pub name: String,

--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -134,6 +134,7 @@ pub struct ScoredVersion {
     PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize, JsonSchema,
 )]
 pub struct PackageSpecifier {
+    #[serde(alias = "type")]
     pub registry: String,
     pub name: String,
     pub version: String,
@@ -378,6 +379,7 @@ pub struct PackageDescriptor {
     pub name: String,
     pub version: String,
     #[serde(rename = "type")]
+    #[serde(alias = "registry")]
     pub package_type: PackageType,
 }
 


### PR DESCRIPTION
This patch updates a few types to make future updates simple. It adds some serde annotations to make the deserialization more permissive. That way future updates are less likely to break things.