### PR TITLE
add `AsRef<str>` to auth string wrappers

### DIFF
--- a/src/types/auth.rs
+++ b/src/types/auth.rs
@@ -15,6 +15,10 @@ impl AuthorizationCode {
     pub fn new(string: impl AsRef<str>) -> Self {
         Self(string.as_ref().to_owned())
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl From<&AuthorizationCode> for String {
@@ -31,7 +35,7 @@ impl fmt::Display for AuthorizationCode {
 
 impl AsRef<str> for AuthorizationCode {
     fn as_ref(&self) -> &str {
-        &self.0
+        self.as_str()
     }
 }
 
@@ -44,6 +48,10 @@ pub struct RefreshToken(String);
 impl RefreshToken {
     pub fn new(string: impl AsRef<str>) -> Self {
         Self(string.as_ref().to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -61,7 +69,7 @@ impl fmt::Display for RefreshToken {
 
 impl AsRef<str> for RefreshToken {
     fn as_ref(&self) -> &str {
-        &self.0
+        self.as_str()
     }
 }
 
@@ -74,6 +82,10 @@ pub struct AccessToken(String);
 impl AccessToken {
     pub fn new(string: impl AsRef<str>) -> Self {
         Self(string.as_ref().to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -97,7 +109,7 @@ impl fmt::Display for AccessToken {
 
 impl AsRef<str> for AccessToken {
     fn as_ref(&self) -> &str {
-        &self.0
+        self.as_str()
     }
 }
 
@@ -110,6 +122,10 @@ pub struct IdToken(String);
 impl IdToken {
     pub fn new(string: impl AsRef<str>) -> Self {
         Self(string.as_ref().to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -127,7 +143,7 @@ impl fmt::Display for IdToken {
 
 impl AsRef<str> for IdToken {
     fn as_ref(&self) -> &str {
-        &self.0
+        self.as_str()
     }
 }
 

--- a/src/types/auth.rs
+++ b/src/types/auth.rs
@@ -29,6 +29,12 @@ impl fmt::Display for AuthorizationCode {
     }
 }
 
+impl AsRef<str> for AuthorizationCode {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Typed wrapper for RefreshToken
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Serialize, Deserialize, JsonSchema,
@@ -50,6 +56,12 @@ impl From<&RefreshToken> for String {
 impl fmt::Display for RefreshToken {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for RefreshToken {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 
@@ -83,6 +95,12 @@ impl fmt::Display for AccessToken {
     }
 }
 
+impl AsRef<str> for AccessToken {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Typed wrapper for IdToken
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Serialize, Deserialize, JsonSchema,
@@ -104,6 +122,12 @@ impl From<&IdToken> for String {
 impl fmt::Display for IdToken {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for IdToken {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 


### PR DESCRIPTION
These structs are String wrappers, but the only way to view the content of the string is to use the `Display` or `String From` implementation to make a new copy of the contained string. We should also be able to obtain a `&str`.

This has the potentially undesirable side effect that now you can write `AuthorizationCode::new(RefreshToken::new(AccessToken::new(IdToken::new(authorization_code))))` because each of these structs has an `fn new(string: impl AsRef<str>) -> Self`. I considered having a `.as_str()` instead to be more explicit, but then I saw the consumer code uses `.into()` to convert these to Strings, so I switched back to `AsRef<str>`.