### PR TITLE
add missing fields from live API

### DIFF
--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -368,7 +368,7 @@ pub struct Package {
     pub is_abandonware: Option<bool>,
 }
 
-#[derive(PartialEq, PartialOrd, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(PartialEq, PartialOrd, Clone, Debug, Default, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct PackageReleaseData {
     pub first_release_date: String,

--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -1,8 +1,9 @@
 //! Module containing data types reprsenting on-the-wire data for packages
 
+use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
-use std::{collections::HashMap, convert::TryFrom};
 
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
@@ -359,6 +360,19 @@ pub struct Package {
     pub developer_responsiveness: Option<DeveloperResponsiveness>,
     pub issue_impacts: IssueImpacts,
     pub complete: bool,
+    pub release_data: Option<PackageReleaseData>,
+    pub repo_url: Option<String>,
+    #[serde(rename = "maintainers_recently_changed")]
+    pub maintainers_recently_changed: Option<bool>,
+    #[serde(rename = "is_abandonware")]
+    pub is_abandonware: Option<bool>,
+}
+
+#[derive(PartialEq, PartialOrd, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct PackageReleaseData {
+    pub first_release_date: String,
+    pub last_release_date: String,
 }
 
 // v--- TODO: OLD PACKAGE RESPONSES ---v //


### PR DESCRIPTION
These fields are present in the live API, but they're missing from phylum_types, which means they get removed from the response when using the CLI with `--json`.