### PR TITLE
Add MIT license to Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "phylum_types"
 description = "Common public types shared between the Phylum CLI and API"
 version = "0.1.0"
+authors = ["Phylum, Inc. <engineering@phylum.io>"]
+license = "MIT"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
While evaluating #53, I noticed that `license` and `authors` were missing from the manifest file for this crate. This patch adds those fields.