### PR TITLE
remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4.11", default-features = false, features = ["serde"] }
-log = "^0.4.6"
 schemars = { version = "0.8", features = ["chrono", "uuid1"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_derive = "1.0"
-uuid = { version = "1.1.2", features = ["serde", "v4"] }
+uuid = { version = "1.1.2", features = ["serde"] }


### PR DESCRIPTION
These dependencies are in cargo.toml but aren't used. Other crates consuming this library don't always need them. The uuid/v4 feature specifically was causing me some problems yesterday.