### PR TITLE
add project ecosystems

### DIFF
--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -33,7 +33,10 @@ pub struct JobDescriptor {
     pub pass: bool,
     pub msg: String,
     pub date: String,
+    // don't deprecate until `ecosystems` is live.
+    //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
+    pub ecosystems: Vec<String>,
     #[serde(default)]
     pub num_incomplete: u32,
 }
@@ -44,6 +47,8 @@ pub struct JobDescriptor {
 )]
 pub struct SubmitPackageRequest {
     /// The 'type' of package, NPM, RubyGem, etc
+    // don't deprecate until `ecosystems` is live.
+    //#[deprecated = "No longer used."]
     #[serde(rename = "type")]
     pub package_type: PackageType,
     /// The subpackage dependencies of this package
@@ -93,7 +98,12 @@ pub struct JobStatusResponse<T> {
     pub job_id: JobId,
     /// The language ecosystem
     /// TODO: How is this different than package type ( npm, etc ) or language?
+    // don't deprecate until `ecosystems` is live.
+    //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
+    /// The language ecosystem
+    /// TODO: How is this different than package type ( npm, etc ) or language?
+    pub ecosystems: Vec<String>,
     /// The id of the user submitting the job
     pub user_id: UserId,
     /// The user email

--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -36,6 +36,7 @@ pub struct JobDescriptor {
     // don't deprecate until `ecosystems` is live.
     //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
+    #[serde(default)]
     pub ecosystems: Vec<String>,
     #[serde(default)]
     pub num_incomplete: u32,
@@ -101,6 +102,7 @@ pub struct JobStatusResponse<T> {
     //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
     /// The language ecosystem
+    #[serde(default)]
     pub ecosystems: Vec<String>,
     /// The id of the user submitting the job
     pub user_id: UserId,

--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -97,12 +97,10 @@ pub struct JobStatusResponse<T> {
     /// The id of the job processing the top level package
     pub job_id: JobId,
     /// The language ecosystem
-    /// TODO: How is this different than package type ( npm, etc ) or language?
     // don't deprecate until `ecosystems` is live.
     //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
     /// The language ecosystem
-    /// TODO: How is this different than package type ( npm, etc ) or language?
     pub ecosystems: Vec<String>,
     /// The id of the user submitting the job
     pub user_id: UserId,

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -32,7 +32,11 @@ pub struct ProjectSummaryResponse {
     /// When the project was created
     pub created_at: DateTime<Utc>,
     /// The ecosystem of the project; determined by its latest job
+    // don't deprecate until `ecosystems` is live.
+    //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: Option<PackageType>,
+    /// The ecosystems of the project; determined by its latest job
+    pub ecosystems: Vec<PackageType>,
     /// The project's group's name, if this is a group project
     pub group_name: Option<String>,
 }
@@ -45,7 +49,11 @@ pub struct ProjectDetailsResponse {
     /// The project id
     pub id: String,
     /// The project ecosystem / package type
+    // don't deprecate until `ecosystems` is live.
+    //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
+    /// The project ecosystems / package types
+    pub ecosystems: Vec<String>,
     /// The configured risk cutoff thresholds for the project
     pub thresholds: ProjectThresholds,
     /// Most recent analysis job runs

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -36,6 +36,7 @@ pub struct ProjectSummaryResponse {
     //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: Option<PackageType>,
     /// The ecosystems of the project; determined by its latest job
+    #[serde(default)]
     pub ecosystems: Vec<PackageType>,
     /// The project's group's name, if this is a group project
     pub group_name: Option<String>,
@@ -53,6 +54,7 @@ pub struct ProjectDetailsResponse {
     //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
     /// The project ecosystems / package types
+    #[serde(default)]
     pub ecosystems: Vec<String>,
     /// The configured risk cutoff thresholds for the project
     pub thresholds: ProjectThresholds,


### PR DESCRIPTION
This PR adds new fields for when a project or job contains packages from multiple ecosystems.

There's a circular dependency here so we need to introduce the new fields to this repository before they are populated. Another PR will be required to uncomment the `#[deprecated]` annotations once the new API has gone live. The existing fields will continue to be populated so existing clients won't be affected, but obviously if there are multiple ecosystems in the same job, code that is only looking for one ecosystem is going to continue seeing only one ecosystem.