### PR TITLE
deprecate single ecosystem properties

### DIFF
--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -33,8 +33,7 @@ pub struct JobDescriptor {
     pub pass: bool,
     pub msg: String,
     pub date: String,
-    // don't deprecate until `ecosystems` is live.
-    //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
+    #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
     #[serde(default)]
     pub ecosystems: Vec<String>,
@@ -48,8 +47,7 @@ pub struct JobDescriptor {
 )]
 pub struct SubmitPackageRequest {
     /// The 'type' of package, NPM, RubyGem, etc
-    // don't deprecate until `ecosystems` is live.
-    //#[deprecated = "No longer used."]
+    #[deprecated = "No longer used."]
     #[serde(rename = "type")]
     pub package_type: PackageType,
     /// The subpackage dependencies of this package
@@ -98,8 +96,7 @@ pub struct JobStatusResponse<T> {
     /// The id of the job processing the top level package
     pub job_id: JobId,
     /// The language ecosystem
-    // don't deprecate until `ecosystems` is live.
-    //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
+    #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
     /// The language ecosystem
     #[serde(default)]

--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -34,7 +34,7 @@ pub struct JobDescriptor {
     pub msg: String,
     pub date: String,
     #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
-    pub ecosystem: String,
+    pub ecosystem: Option<String>,
     #[serde(default)]
     pub ecosystems: Vec<String>,
     #[serde(default)]
@@ -49,7 +49,7 @@ pub struct SubmitPackageRequest {
     /// The 'type' of package, NPM, RubyGem, etc
     #[deprecated = "No longer used."]
     #[serde(rename = "type")]
-    pub package_type: PackageType,
+    pub package_type: Option<PackageType>,
     /// The subpackage dependencies of this package
     pub packages: Vec<PackageDescriptor>,
     /// Was this submitted by a user interactively and not a CI?
@@ -97,7 +97,7 @@ pub struct JobStatusResponse<T> {
     pub job_id: JobId,
     /// The language ecosystem
     #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
-    pub ecosystem: String,
+    pub ecosystem: Option<String>,
     /// The language ecosystem
     #[serde(default)]
     pub ecosystems: Vec<String>,

--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -73,7 +73,7 @@ impl RiskLevel {
 
 impl fmt::Display for RiskLevel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let risk_level = format!("{:?}", self);
+        let risk_level = format!("{self:?}");
         write!(f, "{}", risk_level.to_lowercase())
     }
 }
@@ -126,7 +126,7 @@ impl FromStr for PackageType {
 
 impl fmt::Display for PackageType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let package_type = format!("{:?}", self);
+        let package_type = format!("{self:?}");
         write!(f, "{}", package_type.to_lowercase())
     }
 }
@@ -168,7 +168,7 @@ impl TryFrom<PackageSpecifier> for PackageDescriptor {
             version,
         } = value;
         let package_type = PackageType::from_str(&registry)
-            .map_err(|()| format!("Failed to convert registry {} to package type", registry))?;
+            .map_err(|()| format!("Failed to convert registry {registry} to package type"))?;
         Ok(PackageDescriptor {
             name,
             version,
@@ -263,7 +263,7 @@ impl fmt::Display for RiskType {
             RiskType::LicenseRisk => "LIC",
             RiskType::TotalRisk => "ALL",
         };
-        write!(f, "{}", risk_domain)
+        write!(f, "{risk_domain}")
     }
 }
 

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -32,8 +32,7 @@ pub struct ProjectSummaryResponse {
     /// When the project was created
     pub created_at: DateTime<Utc>,
     /// The ecosystem of the project; determined by its latest job
-    // don't deprecate until `ecosystems` is live.
-    //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
+    #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: Option<PackageType>,
     /// The ecosystems of the project; determined by its latest job
     #[serde(default)]
@@ -50,8 +49,7 @@ pub struct ProjectDetailsResponse {
     /// The project id
     pub id: String,
     /// The project ecosystem / package type
-    // don't deprecate until `ecosystems` is live.
-    //#[deprecated = "Use `ecosystems` to support multiple ecosystems."]
+    #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
     pub ecosystem: String,
     /// The project ecosystems / package types
     #[serde(default)]

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -50,7 +50,7 @@ pub struct ProjectDetailsResponse {
     pub id: String,
     /// The project ecosystem / package type
     #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
-    pub ecosystem: String,
+    pub ecosystem: Option<String>,
     /// The project ecosystems / package types
     #[serde(default)]
     pub ecosystems: Vec<String>,


### PR DESCRIPTION
The API version that sets `ecosystems` has been live on prod long enough we should be able to deprecate these now. API still sets them, but they're redundant and shouldn't be used anymore.