### PR TITLE
accept "malicious"

### DIFF
--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -74,7 +74,7 @@ impl RiskLevel {
 
 impl fmt::Display for RiskLevel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let risk_level = format!("{:?}", self);
+        let risk_level = format!("{self:?}");
         write!(f, "{}", risk_level.to_lowercase())
     }
 }
@@ -127,7 +127,7 @@ impl FromStr for PackageType {
 
 impl fmt::Display for PackageType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let package_type = format!("{:?}", self);
+        let package_type = format!("{self:?}");
         write!(f, "{}", package_type.to_lowercase())
     }
 }
@@ -169,7 +169,7 @@ impl TryFrom<PackageSpecifier> for PackageDescriptor {
             version,
         } = value;
         let package_type = PackageType::from_str(&registry)
-            .map_err(|()| format!("Failed to convert registry {} to package type", registry))?;
+            .map_err(|()| format!("Failed to convert registry {registry} to package type"))?;
         Ok(PackageDescriptor {
             name,
             version,
@@ -268,7 +268,7 @@ impl fmt::Display for RiskType {
             RiskType::LicenseRisk => "LIC",
             RiskType::TotalRisk => "ALL",
         };
-        write!(f, "{}", risk_domain)
+        write!(f, "{risk_domain}")
     }
 }
 

--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -25,7 +25,8 @@ pub enum RiskDomain {
     EngineeringRisk = 1,
     /// Malicious code such as malware or crypto miners
     #[serde(rename = "malicious_code")]
-    MaliciousCode = 2,
+    #[serde(alias = "malicious")]
+    Malicious = 2,
     /// A code vulnerability such as use-after-free or other code smell
     #[serde(rename = "vulnerability")]
     Vulnerabilities = 3,
@@ -184,7 +185,9 @@ impl TryFrom<PackageSpecifier> for PackageDescriptor {
 pub struct RiskScores {
     pub total: f32,
     pub vulnerability: f32,
-    pub malicious_code: f32,
+    #[serde(rename = "malicious_code")]
+    #[serde(alias = "malicious")]
+    pub malicious: f32,
     pub author: f32,
     pub engineering: f32,
     pub license: f32,
@@ -235,7 +238,9 @@ pub struct IssuesListItem {
 pub enum RiskType {
     TotalRisk,
     Vulnerabilities,
-    MaliciousCodeRisk,
+    #[serde(alias = "maliciousRisk")]
+    #[serde(rename = "maliciousCodeRisk")]
+    MaliciousRisk,
     AuthorsRisk,
     EngineeringRisk,
     LicenseRisk,
@@ -244,7 +249,7 @@ pub enum RiskType {
 impl From<RiskDomain> for RiskType {
     fn from(risk_domain: RiskDomain) -> Self {
         match risk_domain {
-            RiskDomain::MaliciousCode => RiskType::MaliciousCodeRisk,
+            RiskDomain::Malicious => RiskType::MaliciousRisk,
             RiskDomain::Vulnerabilities => RiskType::Vulnerabilities,
             RiskDomain::EngineeringRisk => RiskType::EngineeringRisk,
             RiskDomain::AuthorRisk => RiskType::AuthorsRisk,
@@ -256,7 +261,7 @@ impl From<RiskDomain> for RiskType {
 impl fmt::Display for RiskType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let risk_domain = match self {
-            RiskType::MaliciousCodeRisk => "MAL",
+            RiskType::MaliciousRisk => "MAL",
             RiskType::Vulnerabilities => "VLN",
             RiskType::EngineeringRisk => "ENG",
             RiskType::AuthorsRisk => "AUT",

--- a/src/types/preferences.rs
+++ b/src/types/preferences.rs
@@ -28,13 +28,14 @@ pub struct ProjectPreferences {
 
 /// Capture the project threshold settings.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
-#[serde(rename_all = "camelCase")]
 pub struct RiskThresholds {
     pub total: Threshold,
     pub author: Threshold,
     pub engineering: Threshold,
     pub license: Threshold,
-    pub malicious_code: Threshold,
+    #[serde(alias = "malicious")]
+    #[serde(rename = "maliciousCode")]
+    pub malicious: Threshold,
     pub vulnerability: Threshold,
 }
 


### PR DESCRIPTION
This PR adds aliases that remove the "code" from "malicious code".

This allows API to start transitioning from "malicious" "malicious_code" and "maliciousCode" to just "malicious". A future PR will swap the aliases and renames.