### PR TITLE
Update `purl` types for `Rubygems` and `Nuget`

### DIFF
--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -117,7 +117,7 @@ impl FromStr for PackageType {
             "python" | "pypi" => Ok(Self::PyPi),
             "maven" => Ok(Self::Maven),
             "ruby" | "rubygems" | "gem" => Ok(Self::RubyGems),
-            "nuget" => Ok(Self::Nuget),
+            "nuget" | "dotnet" => Ok(Self::Nuget),
             "cargo" => Ok(Self::Cargo),
             "golang" => Ok(Self::Golang),
             _ => Err(()),

--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -116,7 +116,7 @@ impl FromStr for PackageType {
             "npm" => Ok(Self::Npm),
             "python" | "pypi" => Ok(Self::PyPi),
             "maven" => Ok(Self::Maven),
-            "ruby" | "rubygems" => Ok(Self::RubyGems),
+            "ruby" | "rubygems" | "gem" => Ok(Self::RubyGems),
             "nuget" => Ok(Self::Nuget),
             "cargo" => Ok(Self::Cargo),
             "golang" => Ok(Self::Golang),


### PR DESCRIPTION
Update `Rubygems` with the correct `purl` type to aid when extracting the package type from sbom external refs.
Update `Nuget` with additional type of `dotnet`.

See https://github.com/phylum-dev/cli/issues/949 for more info