### PR TITLE
Remove the `is_user` field for job submission

### DIFF
--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -54,8 +54,6 @@ pub struct SubmitPackageRequest {
     pub package_type: PackageType,
     /// The subpackage dependencies of this package
     pub packages: Vec<PackageDescriptor>,
-    /// Was this submitted by a user interactively and not a CI?
-    pub is_user: bool,
     /// The id of the project this top level package should be associated with
     pub project: ProjectId,
     /// A label for this package. Often it's the branch.


### PR DESCRIPTION
This field is ignored by the API, so it can be removed. It will still be sent by old CLI clients, but serde ignores unknown fields during deserialization, so that is fine.