### PR TITLE
Revert "Remove the is_user field for job submission (#68)"

### DIFF
--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -54,6 +54,8 @@ pub struct SubmitPackageRequest {
     pub package_type: PackageType,
     /// The subpackage dependencies of this package
     pub packages: Vec<PackageDescriptor>,
+    /// Was this submitted by a user interactively and not a CI?
+    pub is_user: bool,
     /// The id of the project this top level package should be associated with
     pub project: ProjectId,
     /// A label for this package. Often it's the branch.


### PR DESCRIPTION
This reverts commit 5fb00435f094c4ca7a369ca468d8b70a3e97e7b0 (aka #68).

See [this comment](https://github.com/phylum-dev/phylum-types/pull/68#issuecomment-1462898150) for details.