### PR TITLE
switch to camelCase properties

### DIFF
--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -393,13 +393,12 @@ pub struct Package {
     pub complete: bool,
     pub release_data: Option<PackageReleaseData>,
     pub repo_url: Option<String>,
-    #[serde(rename = "maintainers_recently_changed")]
     pub maintainers_recently_changed: Option<bool>,
-    #[serde(rename = "is_abandonware")]
     pub is_abandonware: Option<bool>,
 }
 
 #[derive(PartialEq, PartialOrd, Clone, Debug, Default, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct PackageReleaseData {
     pub first_release_date: String,


### PR DESCRIPTION
API used to send these properties only in snake_case despite all other properties on the struct being camelCase. It started sending these _also_ in camelCase sometime after September of last year. The snake_case properties are deprecated so we should switch over to using the camelCase properties now when deserializing.

Closes #52 