### PR TITLE
Update package type for maven for parsing sboms

### DIFF
--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -115,7 +115,7 @@ impl FromStr for PackageType {
         match input.to_lowercase().as_str() {
             "npm" => Ok(Self::Npm),
             "python" | "pypi" => Ok(Self::PyPi),
-            "maven" => Ok(Self::Maven),
+            "maven" | "maven-central" => Ok(Self::Maven),
             "ruby" | "rubygems" | "gem" => Ok(Self::RubyGems),
             "nuget" | "dotnet" => Ok(Self::Nuget),
             "cargo" => Ok(Self::Cargo),


### PR DESCRIPTION
SPDX [spec](https://spdx.github.io/spdx-spec/v2.3/external-repository-identifiers/#f31-maven-central) uses `maven-central`