### PR TITLE
remove old deprecated properties again

### DIFF
--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::common::*;
 use super::project::*;
-use crate::types::package::{PackageDescriptor, PackageStatus, PackageStatusExtended, PackageType};
+use crate::types::package::{PackageDescriptor, PackageStatus, PackageStatusExtended};
 
 /// When a job is completed, and some requirement is not met ( such as quality
 /// level ), what action should be taken?
@@ -33,8 +33,6 @@ pub struct JobDescriptor {
     pub pass: bool,
     pub msg: String,
     pub date: String,
-    #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
-    pub ecosystem: Option<String>,
     #[serde(default)]
     pub ecosystems: Vec<String>,
     #[serde(default)]
@@ -46,10 +44,6 @@ pub struct JobDescriptor {
     PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize, JsonSchema,
 )]
 pub struct SubmitPackageRequest {
-    /// The 'type' of package, NPM, RubyGem, etc
-    #[deprecated = "No longer used."]
-    #[serde(rename = "type")]
-    pub package_type: Option<PackageType>,
     /// The subpackage dependencies of this package
     pub packages: Vec<PackageDescriptor>,
     /// Was this submitted by a user interactively and not a CI?
@@ -95,9 +89,6 @@ pub enum JobStatusResponseVariant {
 pub struct JobStatusResponse<T> {
     /// The id of the job processing the top level package
     pub job_id: JobId,
-    /// The language ecosystem
-    #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
-    pub ecosystem: Option<String>,
     /// The language ecosystem
     #[serde(default)]
     pub ecosystems: Vec<String>,

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -31,9 +31,6 @@ pub struct ProjectSummaryResponse {
     pub updated_at: DateTime<Utc>,
     /// When the project was created
     pub created_at: DateTime<Utc>,
-    /// The ecosystem of the project; determined by its latest job
-    #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
-    pub ecosystem: Option<PackageType>,
     /// The ecosystems of the project; determined by its latest job
     #[serde(default)]
     pub ecosystems: Vec<PackageType>,
@@ -48,9 +45,6 @@ pub struct ProjectDetailsResponse {
     pub name: String,
     /// The project id
     pub id: String,
-    /// The project ecosystem / package type
-    #[deprecated = "Use `ecosystems` to support multiple ecosystems."]
-    pub ecosystem: Option<String>,
     /// The project ecosystems / package types
     #[serde(default)]
     pub ecosystems: Vec<String>,


### PR DESCRIPTION
This is #72 again. It was reverted in #74 because CLI wanted to hold off, but it has been two months so probably enough time has passed.