### PR TITLE
Update names for descriptors and specifiers using lockfiles

### DIFF
--- a/src/types/job.rs
+++ b/src/types/job.rs
@@ -5,9 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::common::*;
 use super::project::*;
-use crate::types::package::{
-    PackageDescriptorAndLockfilePath, PackageStatus, PackageStatusExtended,
-};
+use crate::types::package::{PackageDescriptorAndLockfile, PackageStatus, PackageStatusExtended};
 
 /// When a job is completed, and some requirement is not met ( such as quality
 /// level ), what action should be taken?
@@ -31,7 +29,7 @@ pub struct JobDescriptor {
     pub label: String,
     pub num_dependencies: u32,
     pub score: f64,
-    pub packages: Vec<PackageDescriptorAndLockfilePath>,
+    pub packages: Vec<PackageDescriptorAndLockfile>,
     pub pass: bool,
     pub msg: String,
     pub date: String,
@@ -47,7 +45,7 @@ pub struct JobDescriptor {
 )]
 pub struct SubmitPackageRequest {
     /// The subpackage dependencies of this package
-    pub packages: Vec<PackageDescriptorAndLockfilePath>,
+    pub packages: Vec<PackageDescriptorAndLockfile>,
     /// Was this submitted by a user interactively and not a CI?
     pub is_user: bool,
     /// The id of the project this top level package should be associated with

--- a/src/types/package.rs
+++ b/src/types/package.rs
@@ -483,65 +483,63 @@ pub struct PackageDescriptor {
     pub package_type: PackageType,
 }
 
-/// `PackageDescriptorAndLockfilePath` represents a parsed package
-/// (`package_descriptor`) and the optional path to its lockfile
-/// (`lockfile_path`).
+/// `PackageDescriptorAndLockfile` represents a parsed package
+/// (`package_descriptor`) and the optional path to its lockfile (`lockfile`).
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize, JsonSchema,
 )]
-pub struct PackageDescriptorAndLockfilePath {
+pub struct PackageDescriptorAndLockfile {
     #[serde(flatten)]
     pub package_descriptor: PackageDescriptor,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lockfile_path: Option<String>,
+    pub lockfile: Option<String>,
 }
 
-impl From<&PackageDescriptor> for PackageDescriptorAndLockfilePath {
+impl From<&PackageDescriptor> for PackageDescriptorAndLockfile {
     fn from(value: &PackageDescriptor) -> Self {
-        PackageDescriptorAndLockfilePath {
+        PackageDescriptorAndLockfile {
             package_descriptor: value.clone(),
-            lockfile_path: None,
+            lockfile: None,
         }
     }
 }
 
-impl From<PackageDescriptor> for PackageDescriptorAndLockfilePath {
+impl From<PackageDescriptor> for PackageDescriptorAndLockfile {
     fn from(package_descriptor: PackageDescriptor) -> Self {
         Self {
             package_descriptor,
-            lockfile_path: None,
+            lockfile: None,
         }
     }
 }
 
-/// `PackageSpecifierAndLockfilePath` represents a parsed package
-/// (`package_specifier`) and the optional path to its lockfile
-/// (`lockfile_path`).
+/// `PackageSpecifierAndLockfile` represents a parsed package
+/// (`package_specifier`) and the optional path to its lockfile (`lockfile`).
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize, JsonSchema,
 )]
-pub struct PackageSpecifierAndLockfilePath {
+pub struct PackageSpecifierAndLockfile {
     pub package_specifier: PackageSpecifier,
-    pub lockfile_path: Option<String>,
+    pub lockfile: Option<String>,
 }
 
-impl From<&PackageSpecifier> for PackageSpecifierAndLockfilePath {
+impl From<&PackageSpecifier> for PackageSpecifierAndLockfile {
     fn from(value: &PackageSpecifier) -> Self {
-        PackageSpecifierAndLockfilePath {
+        PackageSpecifierAndLockfile {
             package_specifier: value.clone(),
-            lockfile_path: None,
+            lockfile: None,
         }
     }
 }
 
-/// `PackageUrlAndLockfilePath` represents a parsed package (`purl`)
-/// and the optional path to its lockfile (`lockfile_path`).
+/// `PackageUrlAndLockfile` represents a parsed package (`purl`)
+/// and the optional path to its lockfile (`lockfile`).
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Serialize, Deserialize, JsonSchema,
 )]
-pub struct PackageUrlAndLockfilePath {
+pub struct PackageUrlAndLockfile {
     pub purl: String,
-    pub lockfile_path: Option<String>,
+    pub lockfile: Option<String>,
 }
 
 /// Basic core package meta data


### PR DESCRIPTION
Drops `path` from the fields and struct names